### PR TITLE
docs: Add SECURITY.md for responsible vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,3 +50,20 @@ If you believe an API key or sensitive configuration is being handled insecurely
 Please allow the maintainers reasonable time to investigate and address reported issues before any public disclosure.
 
 We appreciate your efforts in helping keep GitGenie safe, reliable, and secure.
+
+## API Key & Configuration Security
+
+GitGenie may require an API key (e.g., for Gemini integration during `gg config`).
+
+To protect sensitive credentials:
+
+- API keys are **not stored in plain text**
+- API keys are **encrypted locally** before being written to disk
+- GitGenie uses **AES-256-CBC encryption** with a per-user encryption key
+- The encryption key is stored securely using the system’s credential manager via **Keytar**
+- The encrypted API key is stored in a local config file:
+  - `~/.gitgenie/config.json`
+
+If Keytar is unavailable or fails, GitGenie falls back to generating a unique encryption key based on machine/user-specific data.
+
+> Note: Users should avoid committing local configuration files and should rotate/revoke API keys immediately if exposure is suspected.


### PR DESCRIPTION
This pull request adds a SECURITY.md file to the repository to define a clear and responsible security disclosure process.

Since GitGenie is an AI-powered Git assistant that automates commits and pushes, having explicit guidance for reporting security-related issues helps prevent accidental public disclosure of sensitive information.

The security policy:
- Encourages private reporting of vulnerabilities
- Aligns with GitHub open-source best practices
- Reflects GitGenie’s CLI-based and AI-assisted workflow (including the --genie flag)

This change is documentation-only and follows the existing contribution guidelines and README.

Closes #26 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SECURITY guidance for privately reporting vulnerabilities and responsible disclosure timelines.
  * Specifies required report contents (description, reproduction steps, CLI usage/flags, potential impact).
  * Clarifies scope of security concerns (credentials, automated repo actions, data loss/unauthorized access).
  * Adds API key/config handling rules and storage recommendations, including encrypted local storage (AES-256-CBC), per-user keys, secure key store fallback, and key rotation guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->