### PR TITLE
Added Local llm support

### DIFF
--- a/cli/commands/config.js
+++ b/cli/commands/config.js
@@ -3,6 +3,10 @@ import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
 import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+// Local providers don't use API keys — they connect to a running local server
+const LOCAL_PROVIDERS = ['ollama', 'lmstudio'];
 
 // Try to import keytar, but make it optional for environments without native dependencies
 let keytar = null;
@@ -264,11 +268,134 @@ export async function setActiveProvider(providerName) {
 
     // Check if provider is configured
     if (!config.providers[providerName]) {
-        throw new Error(`Provider "${providerName}" is not configured. Please configure it first with: gg config <apikey> --provider ${providerName}`);
+        const isLocal = LOCAL_PROVIDERS.includes(providerName.toLowerCase());
+        const hint = isLocal
+            ? `gg config --provider ${providerName} --url <server-url> --model <model-name>`
+            : `gg config <apikey> --provider ${providerName}`;
+        throw new Error(`Provider "${providerName}" is not configured. Please configure it first with: ${hint}`);
     }
 
     config.activeProvider = providerName;
     fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Fetch available models from a local AI server.
+ * Returns an array of model name strings, or empty array if server is unreachable.
+ * @param {string} providerName - 'ollama' | 'lmstudio'
+ * @param {string} baseUrl
+ * @returns {Promise<string[]>}
+ */
+async function fetchAvailableModels(providerName, baseUrl) {
+    try {
+        if (providerName === 'ollama') {
+            const res = await fetch(`${baseUrl.replace(/\/$/, '')}/api/tags`, {
+                signal: AbortSignal.timeout(3000),
+            });
+            if (!res.ok) return [];
+            const data = await res.json();
+            return (data.models || []).map(m => m.name).filter(Boolean);
+        } else {
+            // LM Studio — OpenAI-compatible /v1/models
+            const res = await fetch(`${baseUrl.replace(/\/$/, '')}/v1/models`, {
+                signal: AbortSignal.timeout(3000),
+            });
+            if (!res.ok) return [];
+            const data = await res.json();
+            return (data.data || []).map(m => m.id).filter(Boolean);
+        }
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Determine the model to use for a local provider.
+ * If --model was explicitly given, use it.
+ * Otherwise try to fetch models from the live server:
+ *   - 1 model  → use it automatically
+ *   - multiple → prompt the user to pick one
+ *   - 0 / unreachable → warn and fall back to the default
+ * @param {string} providerName
+ * @param {string} baseUrl
+ * @param {string|undefined} explicitModel - value of --model flag
+ * @param {string} fallbackModel
+ * @returns {Promise<string>}
+ */
+async function resolveModel(providerName, baseUrl, explicitModel, fallbackModel) {
+    if (explicitModel) return explicitModel;
+
+    console.log(chalk.gray(`  Fetching available models from ${baseUrl}...`));
+    const models = await fetchAvailableModels(providerName, baseUrl);
+
+    if (models.length === 0) {
+        console.log(chalk.yellow(`  ⚠  Could not reach server at ${baseUrl} — using default model "${fallbackModel}".`));
+        console.log(chalk.gray(`     Start the server then run: gg config --provider ${providerName} --url ${baseUrl} --model <model>`));
+        return fallbackModel;
+    }
+
+    if (models.length === 1) {
+        console.log(chalk.green(`  ✓ Found model: ${models[0]}`));
+        return models[0];
+    }
+
+    // Multiple models — let the user pick
+    const { chosen } = await inquirer.prompt([
+        {
+            type: 'list',
+            name: 'chosen',
+            message: `Select a model for ${providerName}:`,
+            choices: models,
+        },
+    ]);
+    return chosen;
+}
+
+/**
+ * Save configuration for a local provider (Ollama, LM Studio).
+ * Stores baseUrl and model in config.json — no API key involved.
+ * @param {string} providerName - e.g. 'ollama', 'lmstudio'
+ * @param {string} baseUrl - e.g. 'http://localhost:11434'
+ * @param {string} model - e.g. 'llama3.2'
+ */
+export async function saveLocalProviderConfig(providerName, baseUrl, model) {
+    if (!baseUrl || typeof baseUrl !== 'string' || baseUrl.trim().length === 0) {
+        throw new Error('Base URL must be a non-empty string');
+    }
+    if (!model || typeof model !== 'string' || model.trim().length === 0) {
+        throw new Error('Model name must be a non-empty string');
+    }
+
+    try {
+        if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
+
+        const config = await getProviderConfig();
+        if (!config.providers) config.providers = {};
+
+        config.providers[providerName] = {
+            baseUrl: baseUrl.trim(),
+            model: model.trim(),
+            configuredAt: new Date().toISOString(),
+        };
+        config.activeProvider = providerName;
+
+        fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+        return true;
+    } catch (err) {
+        throw new Error(`Failed to save local provider config: ${err.message}`);
+    }
+}
+
+/**
+ * Get configuration for a local provider.
+ * @param {string} providerName - e.g. 'ollama', 'lmstudio'
+ * @returns {Promise<{baseUrl: string, model: string}|null>}
+ */
+export async function getLocalProviderConfig(providerName) {
+    const config = await getProviderConfig();
+    const providerConfig = config.providers?.[providerName];
+    if (!providerConfig || !providerConfig.baseUrl) return null;
+    return { baseUrl: providerConfig.baseUrl, model: providerConfig.model };
 }
 
 /**
@@ -281,6 +408,24 @@ export async function getActiveProviderInstance() {
     const activeProviderName = await getActiveProvider();
     if (!activeProviderName) return null;
 
+    // Local providers (Ollama, LM Studio): initialize with baseUrl + model, no API key
+    if (ProviderFactory.isLocalProvider(activeProviderName)) {
+        const localConfig = await getLocalProviderConfig(activeProviderName);
+        if (!localConfig) {
+            console.error(chalk.red(`Local provider "${activeProviderName}" is not configured.`));
+            console.log(chalk.cyan(`Run: gg config --provider ${activeProviderName} --url <url> --model <model>`));
+            return null;
+        }
+        try {
+            return ProviderFactory.getProvider(activeProviderName, localConfig);
+        } catch (err) {
+            console.error(chalk.red(`Failed to initialize ${activeProviderName} provider.`));
+            console.error(chalk.yellow(err.message));
+            return null;
+        }
+    }
+
+    // Cloud providers: get encrypted API key (backward compatible)
     const apiKey = await getProviderApiKey(activeProviderName);
     if (!apiKey) return null;
 
@@ -312,8 +457,11 @@ export function registerConfigCommand(program) {
     program
         .command('config [apikey]')
         .description('Save your AI provider API key or check configuration status')
-        .option('--provider <name>', 'Provider name (gemini, mistral, groq)', 'gemini')
+        .option('--provider <name>', 'Provider name (gemini, mistral, groq, ollama, lmstudio)', 'gemini')
         .option('--status', 'Check configuration status of all providers')
+        // Local provider options (ollama / lmstudio)
+        .option('--url <url>', 'Base URL for local AI server (e.g. http://localhost:11434)')
+        .option('--model <model>', 'Model name for local AI provider (e.g. llama3.2)')
         .action(async (apikey, options) => {
             try {
                 const { ProviderFactory } = await import('../providers/index.js');
@@ -326,31 +474,37 @@ export function registerConfigCommand(program) {
                     let hasConfigured = false;
 
                     for (const provider of providers) {
-                        const key = await getProviderApiKey(provider);
-                        const isConfigured = !!key;
-                        const statusColor = isConfigured ? chalk.green : chalk.gray;
-                        const statusIcon = isConfigured ? '✅' : '❌';
-                        const statusText = isConfigured ? 'Configured' : 'Not configured';
                         const padding = ' '.repeat(10 - provider.length);
+                        const label = chalk.cyan(provider.charAt(0).toUpperCase() + provider.slice(1));
 
-                        console.log(`  ${chalk.cyan(provider.charAt(0).toUpperCase() + provider.slice(1))}${padding}: ${statusIcon} ${statusColor(statusText)}`);
-                        if (isConfigured) hasConfigured = true;
+                        if (ProviderFactory.isLocalProvider(provider)) {
+                            // Local providers: show URL + model instead of API key status
+                            const localConfig = await getLocalProviderConfig(provider);
+                            const isConfigured = !!localConfig;
+                            const statusIcon = isConfigured ? '✅' : '❌';
+                            const statusText = isConfigured
+                                ? chalk.green(`${localConfig.baseUrl}  model: ${localConfig.model}`)
+                                : chalk.gray('Not configured');
+                            console.log(`  ${label}${padding}: ${statusIcon} ${statusText}`);
+                            if (isConfigured) hasConfigured = true;
+                        } else {
+                            // Cloud providers: show Configured / Not configured
+                            const key = await getProviderApiKey(provider);
+                            const isConfigured = !!key;
+                            const statusIcon = isConfigured ? '✅' : '❌';
+                            const statusText = isConfigured ? chalk.green('Configured') : chalk.gray('Not configured');
+                            console.log(`  ${label}${padding}: ${statusIcon} ${statusText}`);
+                            if (isConfigured) hasConfigured = true;
+                        }
                     }
 
                     console.log(''); // Empty line
                     if (!hasConfigured) {
                         console.log(chalk.yellow('  No providers configured yet.'));
-                        console.log(chalk.cyan('  Run: gg config <your-key> --provider <name>'));
+                        console.log(chalk.cyan('  Cloud:  gg config <your-key> --provider <name>'));
+                        console.log(chalk.cyan('  Local:  gg config --provider ollama --url http://localhost:11434 --model llama3.2'));
                     }
                     process.exit(0);
-                }
-
-                // Mode 2: Save API Key
-                if (!apikey) {
-                    console.error(chalk.red('Error: API key is required when not using --status'));
-                    console.log(chalk.cyan('Usage: gg config <apikey>'));
-                    console.log(chalk.cyan('Check Status: gg config --status'));
-                    process.exit(1);
                 }
 
                 const providerName = options.provider.toLowerCase();
@@ -359,7 +513,39 @@ export function registerConfigCommand(program) {
                 if (!ProviderFactory.isProviderSupported(providerName)) {
                     console.error(chalk.red(`Unknown AI provider: "${providerName}"`));
                     console.log(chalk.yellow(`Supported providers: ${ProviderFactory.getSupportedProviders().join(', ')}`));
-                    console.log(chalk.cyan('Set your provider with: gg key --gemini <your-key>'));
+                    process.exit(1);
+                }
+
+                // Mode 2a: Save local provider config (Ollama / LM Studio)
+                if (ProviderFactory.isLocalProvider(providerName)) {
+                    const defaults = providerName === 'ollama'
+                        ? { url: 'http://localhost:11434', model: 'llama3.2' }
+                        : { url: 'http://localhost:1234', model: 'llama-3.2-3b-instruct' };
+
+                    // Accept URL from either --url flag or the positional argument
+                    // (users naturally type: gg config http://localhost:11434 --provider ollama)
+                    const urlFromPositional =
+                        apikey && (apikey.startsWith('http://') || apikey.startsWith('https://'))
+                            ? apikey
+                            : null;
+                    const baseUrl = options.url || urlFromPositional || defaults.url;
+
+                    // Resolve model: --model flag → live server query → fallback default
+                    const model = await resolveModel(providerName, baseUrl, options.model, defaults.model);
+
+                    await saveLocalProviderConfig(providerName, baseUrl, model);
+                    console.log(chalk.green(`\n${providerName.charAt(0).toUpperCase() + providerName.slice(1)} configured successfully!`));
+                    console.log(chalk.cyan(`  Server : ${baseUrl}`));
+                    console.log(chalk.cyan(`  Model  : ${model}`));
+                    console.log(chalk.cyan(`  Switch : gg use --${providerName}`));
+                    process.exit(0);
+                }
+
+                // Mode 2b: Save cloud provider API key
+                if (!apikey) {
+                    console.error(chalk.red('Error: API key is required for cloud providers when not using --status'));
+                    console.log(chalk.cyan('Usage: gg config <apikey> --provider <name>'));
+                    console.log(chalk.cyan('Check Status: gg config --status'));
                     process.exit(1);
                 }
 
@@ -367,7 +553,7 @@ export function registerConfigCommand(program) {
                 console.log(chalk.green(`${providerName.charAt(0).toUpperCase() + providerName.slice(1)} API key saved successfully!`));
                 console.log(chalk.cyan(`${providerName} is now your active AI provider`));
             } catch (err) {
-                console.error(chalk.red('Failed to save API key.'));
+                console.error(chalk.red('Failed to save configuration.'));
                 console.error(chalk.yellow(err.message));
             }
             process.exit(0);
@@ -380,6 +566,8 @@ export function registerConfigCommand(program) {
         .option('--gemini', 'Switch to Gemini AI')
         .option('--mistral', 'Switch to Mistral AI')
         .option('--groq', 'Switch to Groq AI')
+        .option('--ollama', 'Switch to Ollama (local)')
+        .option('--lmstudio', 'Switch to LM Studio (local)')
         .action(async (options) => {
             try {
                 let providerName = null;
@@ -387,12 +575,16 @@ export function registerConfigCommand(program) {
                 if (options.gemini) providerName = 'gemini';
                 else if (options.mistral) providerName = 'mistral';
                 else if (options.groq) providerName = 'groq';
+                else if (options.ollama) providerName = 'ollama';
+                else if (options.lmstudio) providerName = 'lmstudio';
 
                 if (!providerName) {
                     console.error(chalk.red('Please specify a provider:'));
                     console.log(chalk.cyan('  gg use --gemini'));
                     console.log(chalk.cyan('  gg use --mistral'));
                     console.log(chalk.cyan('  gg use --groq'));
+                    console.log(chalk.cyan('  gg use --ollama'));
+                    console.log(chalk.cyan('  gg use --lmstudio'));
                     process.exit(1);
                 }
 

--- a/cli/helpers/errorHandler.js
+++ b/cli/helpers/errorHandler.js
@@ -43,6 +43,24 @@ function parseLocalProviderError(error, providerName) {
     const hints = LOCAL_PROVIDER_HINTS[providerName] || LOCAL_PROVIDER_HINTS.ollama;
     const displayName = LOCAL_PROVIDER_NAMES[providerName] || providerName;
 
+    // Context window overflow (e.g. LM Studio HTTP 400 "Cannot truncate prompt")
+    if (
+        msgLow.includes('n_ctx') ||
+        msgLow.includes('context') ||
+        msgLow.includes('truncate prompt') ||
+        msgLow.includes('context length') ||
+        (error?.status === 400 || msgLow.includes('http 400'))
+    ) {
+        return {
+            type: ErrorType.GENERIC_API_ERROR,
+            message: `${displayName}: the diff is too large for this model's context window.`,
+            helpfulAction:
+                `Try loading a model with a larger context window in ${displayName}.\n` +
+                `   Or stage fewer files at a time before committing.\n` +
+                `   ${chalk.gray(hints.configHint)}`,
+        };
+    }
+
     // Server not reachable (thrown by our #ensureRunning guard)
     if (
         msgLow.includes('not reachable') ||

--- a/cli/helpers/errorHandler.js
+++ b/cli/helpers/errorHandler.js
@@ -4,6 +4,97 @@ import path from 'path';
 import os from 'os';
 
 /**
+ * Local providers that run on-device — no API keys, different error surface.
+ */
+const LOCAL_PROVIDERS = ['ollama', 'lmstudio'];
+
+/** Display names for local providers */
+const LOCAL_PROVIDER_NAMES = {
+    ollama: 'Ollama',
+    lmstudio: 'LM Studio',
+};
+
+/** Setup hints for local providers */
+const LOCAL_PROVIDER_HINTS = {
+    ollama: {
+        serverHint: 'Start the server with: ollama serve',
+        modelHint: (model) => `Pull the model with: ollama pull ${model}`,
+        configHint: 'Reconfigure with: gg config --provider ollama --url <url> --model <model>',
+        docsUrl: 'https://ollama.com/library',
+    },
+    lmstudio: {
+        serverHint: 'Open LM Studio → load a model → enable the local server (port 1234)',
+        modelHint: (_model) => 'Make sure a model is loaded and the server is enabled in LM Studio',
+        configHint: 'Reconfigure with: gg config --provider lmstudio --url <url> --model <model>',
+        docsUrl: 'https://lmstudio.ai/docs',
+    },
+};
+
+/**
+ * Parse errors from local AI providers (Ollama, LM Studio).
+ * These have no API keys — errors are about server reachability and model availability.
+ * @param {Error} error
+ * @param {string} providerName - 'ollama' | 'lmstudio'
+ * @returns {Object} { type, message, helpfulAction }
+ */
+function parseLocalProviderError(error, providerName) {
+    const msg = error?.message || '';
+    const msgLow = msg.toLowerCase();
+    const hints = LOCAL_PROVIDER_HINTS[providerName] || LOCAL_PROVIDER_HINTS.ollama;
+    const displayName = LOCAL_PROVIDER_NAMES[providerName] || providerName;
+
+    // Server not reachable (thrown by our #ensureRunning guard)
+    if (
+        msgLow.includes('not reachable') ||
+        msgLow.includes('econnrefused') ||
+        msgLow.includes('etimedout') ||
+        msgLow.includes('timeout') ||
+        msgLow.includes('enotfound') ||
+        msgLow.includes('network') ||
+        error?.code === 'ECONNREFUSED' ||
+        error?.code === 'ETIMEDOUT' ||
+        error?.code === 'ENOTFOUND'
+    ) {
+        return {
+            type: ErrorType.NETWORK_ERROR,
+            message: `${displayName} server is not running or not reachable.`,
+            helpfulAction:
+                `${hints.serverHint}\n` +
+                `   ${chalk.gray(hints.configHint)}`,
+        };
+    }
+
+    // Model not found / not loaded (thrown by our #chat guard)
+    if (
+        msgLow.includes('not found') ||
+        msgLow.includes('not loaded') ||
+        msgLow.includes('model') ||
+        (error?.status === 404)
+    ) {
+        // Try to extract model name from the error message
+        const modelMatch = msg.match(/["\u201c]([^"\u201d]+)["\u201d]/);
+        const modelName = modelMatch ? modelMatch[1] : 'the configured model';
+        return {
+            type: ErrorType.GENERIC_API_ERROR,
+            message: `${displayName}: model "${modelName}" is not available.`,
+            helpfulAction:
+                `${hints.modelHint(modelName)}\n` +
+                `   ${chalk.gray(hints.configHint)}`,
+        };
+    }
+
+    // Generic local error
+    return {
+        type: ErrorType.UNKNOWN_ERROR,
+        message: `${displayName} returned an unexpected error.`,
+        helpfulAction:
+            `Check that ${displayName} is running and the model is loaded.\n` +
+            `   ${chalk.gray(hints.configHint)}\n` +
+            `   Docs: ${chalk.cyan(hints.docsUrl)}`,
+    };
+}
+
+/**
  * Error types for AI provider API failures
  */
 export const ErrorType = {
@@ -55,6 +146,11 @@ function getProviderErrorPatterns(providerName) {
  * @returns {Object} - { type, message, helpfulAction }
  */
 export function parseProviderError(error, providerName = 'gemini') {
+    // Local providers have a completely different error surface — no API keys involved
+    if (LOCAL_PROVIDERS.includes(providerName.toLowerCase())) {
+        return parseLocalProviderError(error, providerName.toLowerCase());
+    }
+
     const errorMessage = error?.message?.toLowerCase() || '';
     const errorString = error?.toString?.()?.toLowerCase() || '';
     const statusCode = error?.status || error?.statusCode;

--- a/cli/index.js
+++ b/cli/index.js
@@ -13,7 +13,8 @@ import path from 'path';
 import crypto from 'crypto';
 const {
   registerConfigCommand,
-  getActiveProviderInstance
+  getActiveProviderInstance,
+  getActiveProvider
 } = await import(
   new URL('./commands/config.js', import.meta.url)
 );
@@ -689,9 +690,16 @@ async function generateCommitMessage(diff, opts, desc) {
 
   if (!opts.genie || !provider) {
     if (opts.genie && !provider) {
+      const { ProviderFactory } = await import(new URL('./providers/index.js', import.meta.url));
+      const isLocal = providerName && ProviderFactory.isLocalProvider(providerName);
       console.warn(chalk.yellow('⚠ AI provider not configured. Falling back to manual commit message.'));
-      console.warn(chalk.cyan('To enable AI commit messages, configure an API key:'));
-      console.warn(chalk.gray('Example: gg config <your_api_key> --provider gemini'));
+      if (isLocal) {
+        console.warn(chalk.cyan(`To enable AI commit messages, make sure your ${providerName} server is running and configured:`));
+        console.warn(chalk.gray(`Example: gg config --provider ${providerName} --url <url> --model <model>`));
+      } else {
+        console.warn(chalk.cyan('To enable AI commit messages, configure an API key:'));
+        console.warn(chalk.gray('Example: gg config <your_api_key> --provider gemini'));
+      }
     }
     return `${opts.type}${opts.scope ? `(${opts.scope})` : ''}: ${desc}`;
   }
@@ -715,9 +723,16 @@ async function generatePRTitle(diff, opts, desc) {
 
   if (!opts.genie || !provider) {
     if (opts.genie && !provider) {
+      const { ProviderFactory } = await import(new URL('./providers/index.js', import.meta.url));
+      const isLocal = providerName && ProviderFactory.isLocalProvider(providerName);
       console.warn(chalk.yellow('⚠ AI provider not configured. Falling back to manual PR title.'));
-      console.warn(chalk.cyan('To enable AI PR titles, configure an API key:'));
-      console.warn(chalk.gray('Example: gg config <your_api_key> --provider gemini'));
+      if (isLocal) {
+        console.warn(chalk.cyan(`To enable AI PR titles, make sure your ${providerName} server is running and configured:`));
+        console.warn(chalk.gray(`Example: gg config --provider ${providerName} --url <url> --model <model>`));
+      } else {
+        console.warn(chalk.cyan('To enable AI PR titles, configure an API key:'));
+        console.warn(chalk.gray('Example: gg config <your_api_key> --provider gemini'));
+      }
     }
     return `${opts.type}${opts.scope ? `(${opts.scope})` : ''}: ${desc}`;
   }

--- a/cli/providers/base.js
+++ b/cli/providers/base.js
@@ -1,16 +1,37 @@
 /**
  * Base abstract class for AI providers
  * All AI providers must extend this class and implement its methods
+ *
+ * Cloud providers: pass apiKey as a string (strict validation preserved)
+ * Local providers: pass a config object { baseUrl, model } — no API key needed
  */
 export class AIProvider {
-    constructor(apiKey) {
+    constructor(apiKeyOrConfig) {
         if (new.target === AIProvider) {
             throw new Error('AIProvider is an abstract class and cannot be instantiated directly');
         }
-        if (!apiKey || typeof apiKey !== 'string') {
-            throw new Error('API key is required and must be a string');
+
+        if (apiKeyOrConfig !== null && typeof apiKeyOrConfig === 'object') {
+            // Local provider path — config object { baseUrl, model }
+            this.apiKey = null;
+            this.localConfig = apiKeyOrConfig;
+        } else {
+            // Cloud provider path — strict API key validation (backward compat)
+            if (!apiKeyOrConfig || typeof apiKeyOrConfig !== 'string') {
+                throw new Error('API key is required and must be a string');
+            }
+            this.apiKey = apiKeyOrConfig;
+            this.localConfig = null;
         }
-        this.apiKey = apiKey;
+    }
+
+    /**
+     * Whether this provider runs locally (no API key required).
+     * Local providers override this to return true.
+     * @returns {boolean}
+     */
+    isLocalProvider() {
+        return false;
     }
 
     /**

--- a/cli/providers/index.js
+++ b/cli/providers/index.js
@@ -1,6 +1,8 @@
 import { GeminiProvider } from './gemini.js';
 import { MistralProvider } from './mistral.js';
 import { GroqProvider } from './groq.js';
+import { OllamaProvider } from './ollama.js';
+import { LMStudioProvider } from './lmstudio.js';
 
 /**
  * Provider registry and factory
@@ -10,15 +12,22 @@ export class ProviderFactory {
         gemini: GeminiProvider,
         mistral: MistralProvider,
         groq: GroqProvider,
+        ollama: OllamaProvider,
+        lmstudio: LMStudioProvider,
     };
 
     /**
+     * Providers that run locally and require a baseUrl + model instead of an API key.
+     */
+    static localProviders = ['ollama', 'lmstudio'];
+
+    /**
      * Get an instance of the specified provider
-     * @param {string} providerName - Name of the provider (gemini, mistral)
-     * @param {string} apiKey - API key for the provider
+     * @param {string} providerName - Name of the provider (gemini, mistral, groq, ollama, lmstudio)
+     * @param {string|Object} apiKeyOrConfig - API key string for cloud providers, or {baseUrl, model} for local providers
      * @returns {AIProvider} Provider instance
      */
-    static getProvider(providerName, apiKey) {
+    static getProvider(providerName, apiKeyOrConfig) {
         const normalizedName = providerName.toLowerCase();
         const ProviderClass = this.providers[normalizedName];
 
@@ -26,7 +35,7 @@ export class ProviderFactory {
             throw new Error(`Unknown provider: ${providerName}. Supported providers: ${this.getSupportedProviders().join(', ')}`);
         }
 
-        return new ProviderClass(apiKey);
+        return new ProviderClass(apiKeyOrConfig);
     }
 
     /**
@@ -52,5 +61,14 @@ export class ProviderFactory {
      */
     static isProviderSupported(providerName) {
         return this.providers.hasOwnProperty(providerName.toLowerCase());
+    }
+
+    /**
+     * Check if a provider is a local provider (no API key required).
+     * @param {string} providerName - Provider name to check
+     * @returns {boolean} True if local provider
+     */
+    static isLocalProvider(providerName) {
+        return this.localProviders.includes(providerName.toLowerCase());
     }
 }

--- a/cli/providers/lmstudio.js
+++ b/cli/providers/lmstudio.js
@@ -1,0 +1,237 @@
+import { AIProvider } from './base.js';
+import ora from 'ora';
+
+/**
+ * LM Studio local AI provider.
+ *
+ * LM Studio exposes a fully OpenAI-compatible REST API at /v1/chat/completions.
+ * No API key required — requires LM Studio to be running with a model loaded.
+ *
+ * Default server: http://localhost:1234
+ * Configure with: gg config --provider lmstudio --url <url> --model <model>
+ */
+export class LMStudioProvider extends AIProvider {
+    constructor(config = {}) {
+        super(config);
+        this.baseUrl = (config.baseUrl || 'http://localhost:1234').replace(/\/$/, '');
+        this.model = config.model || 'llama-3.2-3b-instruct';
+    }
+
+    isLocalProvider() { return true; }
+    getName() { return 'lmstudio'; }
+    getModelName() { return this.model; }
+    getDocsUrl() { return 'https://lmstudio.ai/docs'; }
+    validateApiKey() { return true; }
+
+    async ping() {
+        try {
+            const res = await fetch(`${this.baseUrl}/v1/models`, { signal: AbortSignal.timeout(3000) });
+            return res.ok;
+        } catch { return false; }
+    }
+
+    async #ensureRunning() {
+        if (!(await this.ping())) {
+            throw new Error(
+                `LM Studio server not reachable at ${this.baseUrl}.\n` +
+                `  • Open LM Studio, load a model, and enable the local server (port 1234)\n` +
+                `  • Or change the URL with: gg config --provider lmstudio --url <url> --model <model>`
+            );
+        }
+    }
+
+    async #chat(prompt, maxTokens = 500) {
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                model: this.model,
+                messages: [{ role: 'user', content: prompt }],
+                temperature: 0.3,
+                max_tokens: maxTokens,
+                stream: false,
+            }),
+            signal: AbortSignal.timeout(60000),
+        });
+
+        if (!response.ok) {
+            const errText = await response.text().catch(() => '');
+            if (
+                response.status === 404 ||
+                errText.toLowerCase().includes('not found') ||
+                errText.toLowerCase().includes('not loaded')
+            ) {
+                throw new Error(
+                    `Model "${this.model}" is not loaded in LM Studio.\n` +
+                    `  • Open LM Studio and load the model: ${this.model}\n` +
+                    `  • Or reconfigure with: gg config --provider lmstudio --url <url> --model <model>`
+                );
+            }
+            throw new Error(`LM Studio API error (HTTP ${response.status}): ${errText}`);
+        }
+
+        const data = await response.json();
+        return data.choices?.[0]?.message?.content?.trim() ?? '';
+    }
+
+    async generateCommitMessage(diff, opts, desc) {
+        await this.#ensureRunning();
+        const prompt = `You are a senior software engineer. Generate a professional git commit message.
+
+REQUIREMENTS:
+- Follow Conventional Commits specification exactly
+- Format: type(scope): description
+- Description must be under 50 characters
+- Use imperative mood (add, fix, update, not adds, fixes, updates)
+- First letter of description lowercase
+- No period at the end
+- Choose appropriate type: feat, fix, docs, style, refactor, test, chore, ci, build, perf
+- Include scope when relevant (component/module/area affected)
+
+Code diff to analyze:
+${diff}
+
+Return ONLY the commit message, no explanations or quotes.`;
+        return (await this.#chat(prompt, 100)) || `${opts.type}: ${desc}`;
+    }
+
+    async generatePRTitle(diff, opts, desc) {
+        await this.#ensureRunning();
+        const prompt = `You are a senior software engineer creating a Pull Request title.
+
+REQUIREMENTS:
+- Clear, concise description of changes
+- Under 60 characters
+- Use imperative mood
+- No period at end
+- Professional tone
+
+Code diff to analyze:
+${diff}
+
+Context: ${desc}
+
+Return ONLY the PR title, no explanations or quotes.`;
+        return (await this.#chat(prompt, 50)) || desc;
+    }
+
+    async generateBranchName(desc, opts) {
+        await this.#ensureRunning();
+        const prompt = `Generate a git branch name following best practices.
+
+REQUIREMENTS:
+- Format: type/short-description
+- Use kebab-case (lowercase with hyphens)
+- Keep under 40 characters
+- Types: feature, bugfix, hotfix, refactor, docs, test, chore
+- No special characters except hyphens and slashes
+
+Description: ${desc}
+
+Return ONLY the branch name, no explanations or quotes.`;
+        return (await this.#chat(prompt, 30)) || `feature/${desc.toLowerCase().replace(/\s+/g, '-')}`;
+    }
+
+    async groupFilesWithAI(filesData, maxGroups = 5) {
+        const spinner = ora(`🧞 Analyzing changes with LM Studio (${this.model})...`).start();
+        try {
+            await this.#ensureRunning();
+            const fileSummary = filesData.files.map(f => {
+                const diff = filesData.diffs[f.path] || '';
+                const truncatedDiff = diff.length > 500 ? diff.substring(0, 500) + '\n... (truncated)' : diff;
+                return { path: f.path, status: f.status, diff: truncatedDiff };
+            });
+
+            const prompt = `You are a senior software engineer analyzing git changes to create logical, atomic commits.
+TASK: Analyze the following staged files and group them into separate commits based on semantic relationships.
+RULES:
+1. Each group should represent ONE logical change (feature, fix, refactor, etc.)
+2. Related files should be grouped together (e.g., component + test + styles)
+3. Unrelated changes should be in separate groups
+4. Maximum ${maxGroups} groups
+5. Each group must have a clear purpose
+6. Follow Conventional Commits specification for types
+
+FILES AND CHANGES:
+${JSON.stringify(fileSummary, null, 2)}
+
+Return a JSON array of groups with this structure:
+[
+  {
+    "files": ["path/to/file1.js", "path/to/file2.test.js"],
+    "type": "feat|fix|docs|style|refactor|test|chore|ci|build|perf",
+    "scope": "component/module name (optional)",
+    "description": "brief description of this group's changes",
+    "rationale": "why these files belong together"
+  }
+]
+
+IMPORTANT:
+- Every file must be assigned to exactly one group
+- Groups should be ordered by importance (most significant first)
+- Return ONLY valid JSON, no explanations or markdown code blocks
+- If scope is not applicable, use empty string ""`;
+
+            const responseText = await this.#chat(prompt, 2000);
+            spinner.succeed(`✓ LM Studio (${this.model}) analysis complete`);
+
+            let jsonText = responseText;
+            const jsonMatch = responseText.match(/```(?:json)?\s*(\[[\s\S]*\])\s*```/);
+            if (jsonMatch) jsonText = jsonMatch[1];
+
+            const groups = JSON.parse(jsonText);
+            if (!Array.isArray(groups)) throw new Error('AI response is not an array');
+
+            groups.forEach((group, idx) => {
+                if (!group.files || !Array.isArray(group.files)) throw new Error(`Group ${idx} missing files array`);
+                if (!group.type) group.type = 'chore';
+                if (!group.scope) group.scope = '';
+                if (!group.description) group.description = 'changes';
+                if (!group.rationale) group.rationale = '';
+            });
+
+            return groups;
+        } catch (err) {
+            spinner.fail(`LM Studio (${this.model}) analysis failed`);
+            if (err instanceof SyntaxError) throw new Error('Failed to parse AI response as JSON');
+            throw err;
+        }
+    }
+
+    async generateCommitMessageForGroup(group, filesData) {
+        const manualMessage = `${group.type}${group.scope ? `(${group.scope})` : ''}: ${group.description}`;
+        try {
+            await this.#ensureRunning();
+            const groupDiffs = group.files.map(file => {
+                const diff = filesData.diffs[file] || '';
+                const truncated = diff.length > 300 ? diff.substring(0, 300) + '\n... (truncated)' : diff;
+                return `File: ${file}\n${truncated}`;
+            }).join('\n---\n');
+
+            const prompt = `You are a senior software engineer creating a git commit message.
+Generate a professional commit message following Conventional Commits specification.
+REQUIREMENTS:
+- Format: type(scope): description
+- Description under 50 characters
+- Imperative mood (add, fix, update)
+- Lowercase description
+- No period at end
+- Type: ${group.type}
+${group.scope ? `- Scope: ${group.scope}` : ''}
+
+FILES IN THIS COMMIT:
+${group.files.join('\n')}
+
+CHANGES:
+${groupDiffs}
+
+CONTEXT: ${group.description}
+
+Return ONLY the commit message, no quotes or explanations.`;
+
+            const message = (await this.#chat(prompt, 100)) || manualMessage;
+            if (message.length > 72 || !message.includes(':')) return manualMessage;
+            return message;
+        } catch { return manualMessage; }
+    }
+}

--- a/cli/providers/lmstudio.js
+++ b/cli/providers/lmstudio.js
@@ -23,6 +23,9 @@ export class LMStudioProvider extends AIProvider {
     getDocsUrl() { return 'https://lmstudio.ai/docs'; }
     validateApiKey() { return true; }
 
+    // Max diff characters to send — keeps prompt safely within small context windows
+    static MAX_DIFF_CHARS = 3000;
+
     async ping() {
         try {
             const res = await fetch(`${this.baseUrl}/v1/models`, { signal: AbortSignal.timeout(3000) });
@@ -76,6 +79,9 @@ export class LMStudioProvider extends AIProvider {
 
     async generateCommitMessage(diff, opts, desc) {
         await this.#ensureRunning();
+        const safeDiff = diff.length > LMStudioProvider.MAX_DIFF_CHARS
+            ? diff.substring(0, LMStudioProvider.MAX_DIFF_CHARS) + '\n... (diff truncated to fit context window)'
+            : diff;
         const prompt = `You are a senior software engineer. Generate a professional git commit message.
 
 REQUIREMENTS:
@@ -89,7 +95,7 @@ REQUIREMENTS:
 - Include scope when relevant (component/module/area affected)
 
 Code diff to analyze:
-${diff}
+${safeDiff}
 
 Return ONLY the commit message, no explanations or quotes.`;
         return (await this.#chat(prompt, 100)) || `${opts.type}: ${desc}`;
@@ -97,6 +103,9 @@ Return ONLY the commit message, no explanations or quotes.`;
 
     async generatePRTitle(diff, opts, desc) {
         await this.#ensureRunning();
+        const safeDiff = diff.length > LMStudioProvider.MAX_DIFF_CHARS
+            ? diff.substring(0, LMStudioProvider.MAX_DIFF_CHARS) + '\n... (diff truncated to fit context window)'
+            : diff;
         const prompt = `You are a senior software engineer creating a Pull Request title.
 
 REQUIREMENTS:
@@ -107,7 +116,7 @@ REQUIREMENTS:
 - Professional tone
 
 Code diff to analyze:
-${diff}
+${safeDiff}
 
 Context: ${desc}
 

--- a/cli/providers/ollama.js
+++ b/cli/providers/ollama.js
@@ -1,0 +1,233 @@
+import { AIProvider } from './base.js';
+import ora from 'ora';
+
+/**
+ * Ollama local AI provider.
+ *
+ * Uses Ollama's OpenAI-compatible endpoint (/v1/chat/completions), available
+ * since Ollama 0.1.24. No API key required — requires a running Ollama server.
+ *
+ * Default server: http://localhost:11434
+ * Configure with: gg config --provider ollama --url <url> --model <model>
+ */
+export class OllamaProvider extends AIProvider {
+    constructor(config = {}) {
+        super(config);
+        this.baseUrl = (config.baseUrl || 'http://localhost:11434').replace(/\/$/, '');
+        this.model = config.model || 'llama3.2';
+    }
+
+    isLocalProvider() { return true; }
+    getName() { return 'ollama'; }
+    getModelName() { return this.model; }
+    getDocsUrl() { return 'https://ollama.com/library'; }
+    validateApiKey() { return true; }
+
+    async ping() {
+        try {
+            const res = await fetch(`${this.baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
+            return res.ok;
+        } catch { return false; }
+    }
+
+    async #ensureRunning() {
+        if (!(await this.ping())) {
+            throw new Error(
+                `Ollama server not reachable at ${this.baseUrl}.\n` +
+                `  • Start it with: ollama serve\n` +
+                `  • Or change the URL with: gg config --provider ollama --url <url> --model <model>`
+            );
+        }
+    }
+
+    async #chat(prompt, maxTokens = 500) {
+        const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                model: this.model,
+                messages: [{ role: 'user', content: prompt }],
+                temperature: 0.3,
+                max_tokens: maxTokens,
+                stream: false,
+            }),
+            signal: AbortSignal.timeout(60000),
+        });
+
+        if (!response.ok) {
+            const errText = await response.text().catch(() => '');
+            if (response.status === 404 || errText.toLowerCase().includes('not found')) {
+                throw new Error(
+                    `Model "${this.model}" not found in Ollama.\n` +
+                    `  • Pull it with: ollama pull ${this.model}\n` +
+                    `  • List available models with: ollama list`
+                );
+            }
+            throw new Error(`Ollama API error (HTTP ${response.status}): ${errText}`);
+        }
+
+        const data = await response.json();
+        return data.choices?.[0]?.message?.content?.trim() ?? '';
+    }
+
+    async generateCommitMessage(diff, opts, desc) {
+        await this.#ensureRunning();
+        const prompt = `You are a senior software engineer. Generate a professional git commit message.
+
+REQUIREMENTS:
+- Follow Conventional Commits specification exactly
+- Format: type(scope): description
+- Description must be under 50 characters
+- Use imperative mood (add, fix, update, not adds, fixes, updates)
+- First letter of description lowercase
+- No period at the end
+- Choose appropriate type: feat, fix, docs, style, refactor, test, chore, ci, build, perf
+- Include scope when relevant (component/module/area affected)
+
+Code diff to analyze:
+${diff}
+
+Return ONLY the commit message, no explanations or quotes.`;
+        return (await this.#chat(prompt, 100)) || `${opts.type}: ${desc}`;
+    }
+
+    async generatePRTitle(diff, opts, desc) {
+        await this.#ensureRunning();
+        const prompt = `You are a senior software engineer creating a Pull Request title.
+
+REQUIREMENTS:
+- Clear, concise description of changes
+- Under 60 characters
+- Use imperative mood
+- No period at end
+- Professional tone
+
+Code diff to analyze:
+${diff}
+
+Context: ${desc}
+
+Return ONLY the PR title, no explanations or quotes.`;
+        return (await this.#chat(prompt, 50)) || desc;
+    }
+
+    async generateBranchName(desc, opts) {
+        await this.#ensureRunning();
+        const prompt = `Generate a git branch name following best practices.
+
+REQUIREMENTS:
+- Format: type/short-description
+- Use kebab-case (lowercase with hyphens)
+- Keep under 40 characters
+- Types: feature, bugfix, hotfix, refactor, docs, test, chore
+- No special characters except hyphens and slashes
+
+Description: ${desc}
+
+Return ONLY the branch name, no explanations or quotes.`;
+        return (await this.#chat(prompt, 30)) || `feature/${desc.toLowerCase().replace(/\s+/g, '-')}`;
+    }
+
+    async groupFilesWithAI(filesData, maxGroups = 5) {
+        const spinner = ora(`🧞 Analyzing changes with Ollama (${this.model})...`).start();
+        try {
+            await this.#ensureRunning();
+            const fileSummary = filesData.files.map(f => {
+                const diff = filesData.diffs[f.path] || '';
+                const truncatedDiff = diff.length > 500 ? diff.substring(0, 500) + '\n... (truncated)' : diff;
+                return { path: f.path, status: f.status, diff: truncatedDiff };
+            });
+
+            const prompt = `You are a senior software engineer analyzing git changes to create logical, atomic commits.
+TASK: Analyze the following staged files and group them into separate commits based on semantic relationships.
+RULES:
+1. Each group should represent ONE logical change (feature, fix, refactor, etc.)
+2. Related files should be grouped together (e.g., component + test + styles)
+3. Unrelated changes should be in separate groups
+4. Maximum ${maxGroups} groups
+5. Each group must have a clear purpose
+6. Follow Conventional Commits specification for types
+
+FILES AND CHANGES:
+${JSON.stringify(fileSummary, null, 2)}
+
+Return a JSON array of groups with this structure:
+[
+  {
+    "files": ["path/to/file1.js", "path/to/file2.test.js"],
+    "type": "feat|fix|docs|style|refactor|test|chore|ci|build|perf",
+    "scope": "component/module name (optional)",
+    "description": "brief description of this group's changes",
+    "rationale": "why these files belong together"
+  }
+]
+
+IMPORTANT:
+- Every file must be assigned to exactly one group
+- Groups should be ordered by importance (most significant first)
+- Return ONLY valid JSON, no explanations or markdown code blocks
+- If scope is not applicable, use empty string ""`;
+
+            const responseText = await this.#chat(prompt, 2000);
+            spinner.succeed(`✓ Ollama (${this.model}) analysis complete`);
+
+            let jsonText = responseText;
+            const jsonMatch = responseText.match(/```(?:json)?\s*(\[[\s\S]*\])\s*```/);
+            if (jsonMatch) jsonText = jsonMatch[1];
+
+            const groups = JSON.parse(jsonText);
+            if (!Array.isArray(groups)) throw new Error('AI response is not an array');
+
+            groups.forEach((group, idx) => {
+                if (!group.files || !Array.isArray(group.files)) throw new Error(`Group ${idx} missing files array`);
+                if (!group.type) group.type = 'chore';
+                if (!group.scope) group.scope = '';
+                if (!group.description) group.description = 'changes';
+                if (!group.rationale) group.rationale = '';
+            });
+
+            return groups;
+        } catch (err) {
+            spinner.fail(`Ollama (${this.model}) analysis failed`);
+            if (err instanceof SyntaxError) throw new Error('Failed to parse AI response as JSON');
+            throw err;
+        }
+    }
+
+    async generateCommitMessageForGroup(group, filesData) {
+        const manualMessage = `${group.type}${group.scope ? `(${group.scope})` : ''}: ${group.description}`;
+        try {
+            await this.#ensureRunning();
+            const groupDiffs = group.files.map(file => {
+                const diff = filesData.diffs[file] || '';
+                const truncated = diff.length > 300 ? diff.substring(0, 300) + '\n... (truncated)' : diff;
+                return `File: ${file}\n${truncated}`;
+            }).join('\n---\n');
+
+            const prompt = `You are a senior software engineer creating a git commit message.
+Generate a professional commit message following Conventional Commits specification.
+REQUIREMENTS:
+- Format: type(scope): description
+- Description under 50 characters
+- Imperative mood (add, fix, update)
+- Lowercase description
+- No period at end
+- Type: ${group.type}
+${group.scope ? `- Scope: ${group.scope}` : ''}
+
+FILES IN THIS COMMIT:
+${group.files.join('\n')}
+
+CHANGES:
+${groupDiffs}
+
+CONTEXT: ${group.description}
+
+Return ONLY the commit message, no quotes or explanations.`;
+
+            const message = (await this.#chat(prompt, 100)) || manualMessage;
+            if (message.length > 72 || !message.includes(':')) return manualMessage;
+            return message;
+        } catch { return manualMessage; }
+    }
+}

--- a/cli/providers/ollama.js
+++ b/cli/providers/ollama.js
@@ -23,6 +23,9 @@ export class OllamaProvider extends AIProvider {
     getDocsUrl() { return 'https://ollama.com/library'; }
     validateApiKey() { return true; }
 
+    // Max diff characters to send — keeps prompt safely within small context windows
+    static MAX_DIFF_CHARS = 3000;
+
     async ping() {
         try {
             const res = await fetch(`${this.baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
@@ -72,6 +75,9 @@ export class OllamaProvider extends AIProvider {
 
     async generateCommitMessage(diff, opts, desc) {
         await this.#ensureRunning();
+        const safeDiff = diff.length > OllamaProvider.MAX_DIFF_CHARS
+            ? diff.substring(0, OllamaProvider.MAX_DIFF_CHARS) + '\n... (diff truncated to fit context window)'
+            : diff;
         const prompt = `You are a senior software engineer. Generate a professional git commit message.
 
 REQUIREMENTS:
@@ -85,7 +91,7 @@ REQUIREMENTS:
 - Include scope when relevant (component/module/area affected)
 
 Code diff to analyze:
-${diff}
+${safeDiff}
 
 Return ONLY the commit message, no explanations or quotes.`;
         return (await this.#chat(prompt, 100)) || `${opts.type}: ${desc}`;
@@ -93,6 +99,9 @@ Return ONLY the commit message, no explanations or quotes.`;
 
     async generatePRTitle(diff, opts, desc) {
         await this.#ensureRunning();
+        const safeDiff = diff.length > OllamaProvider.MAX_DIFF_CHARS
+            ? diff.substring(0, OllamaProvider.MAX_DIFF_CHARS) + '\n... (diff truncated to fit context window)'
+            : diff;
         const prompt = `You are a senior software engineer creating a Pull Request title.
 
 REQUIREMENTS:
@@ -103,7 +112,7 @@ REQUIREMENTS:
 - Professional tone
 
 Code diff to analyze:
-${diff}
+${safeDiff}
 
 Context: ${desc}
 


### PR DESCRIPTION
## 📝 Description
Changed Files

[base.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Modified: Extended the AIProvider base constructor so it accepts either a string (cloud API key) or an object { baseUrl, model } for local providers. Added an isLocalProvider() hook (defaults to false) so provider-specific flows can branch cleanly.

[ollama.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
New: Full provider implementation for Ollama. Implements the provider interface, pings /api/tags to detect availability, calls /v1/chat/completions for generation, and applies MAX_DIFF_CHARS = 3000 truncation plus request timeouts and actionable error messages.

[lmstudio.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
New: Full provider implementation for LM Studio. Mirrors Ollama behavior but pings /v1/models and includes LM Studio–specific error/hint text. Also includes diff truncation and timeout guards.

[index.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Modified: Registers the new local providers and adds localProviders + isLocalProvider(name) helpers so the rest of the CLI can detect local vs cloud providers and adjust UX/validation.

[config.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Modified: Adds local-provider config functions (saveLocalProviderConfig, getLocalProviderConfig), live model discovery (fetchAvailableModels), model resolution (resolveModel) with auto-pick and interactive selection, and extends gg config/gg use to accept --url/--model and --ollama/--lmstudio. --status now displays URL + model for local providers.

[index.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Modified: Fixed missing import (getActiveProvider) and updated provider-not-configured hints to be provider-aware (show URL/model advice for local providers instead of API key instructions).

[errorHandler.js](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Modified: Added parseLocalProviderError() and local-provider error branches to produce actionable messages for server unreachable, model-not-found/loaded, and context-window overflow (HTTP 400 / n_ctx) cases. Cloud error handling remains unchanged.

How It Works
Local providers expose an OpenAI-compatible /v1/chat/completions endpoint. GitGenie uses native [fetch](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [AbortSignal.timeout()](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — no new dependencies. Config is stored in [~/.gitgenie/config.json](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as [{baseUrl, model, configuredAt}](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of an encrypted API key.

Setup Instructions
Option A — Ollama
# 1. Install Ollama
curl -fsSL https://ollama.com/install.sh | sh
# 2. Pull a model
ollama pull llama3.2          # ~2 GB, fast on CPU
# 3. Ollama starts automatically; verify it's running
curl http://localhost:11434/api/tags

OPTION B- Lmstudio
1. Download from https://lmstudio.ai and install
2. Open LM Studio → search and download a model (e.g., Llama 3.2 3B Instruct)
3. Go to Local Server tab → click "Start Server"
4. Default port: 1234

Fixes #109 

---

## 🚀 Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 **Documentation update** (adding/improving docs or Mermaid diagrams)
- [ ] 🎨 **Style/Refactor** (non-functional changes, formatting, or renaming)

---

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- **Test Environment:** - **Node Version:** (e.g., v20.x)  v24.13.1
  - **OS:** (e.g., Windows 11, macOS, Ubuntu) Linux Fedora
  - **Shell:** (e.g., PowerShell, Bash, Zsh) Bash

- **Command(s) Executed:**
  - `gg <your-test-command-here>` 
  - gg config --provider lmstudio
  - gg --remote https://github.com/CodeMaster11000/GitGenie.git
  - gg "added local llm support" --genie --type update

- **Expected Result:**
  - (Describe what should happen)
 To be able to get commit message generated by a local llm .The one i used was google/gemma-3-4b from lm studio
- **Actual Result:**
  - (Describe what actually happened/attach logs)
   ✔ Current branch is "local-llm-support". Where do you want to commit? Commit to current branch (local-llm-support)
Committing to current branch: local-llm-support

⚠️  You have modified files, but nothing is staged yet.
Run git add <file> or git add . to stage your changes before committing.

Staging all files...
✔  All files staged
⠋ 🧞 Generating commit message with lmstudio...(node:9465) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔  Commit message generated by lmstudio
Committed changes with message: "update: added local llm support"
✔ Do you want to push branch "local-llm-support" to remote? Yes
---

## ⚠️ Breaking Changes
- [x] **No**
- [ ] **Yes** (If yes, please explain the impact and why it is necessary)

---

## 📸 Screenshots / Logs

<details>
<summary>Click to expand logs</summary>

https://github.com/user-attachments/assets/d2fd1abe-a3d3-45c3-8d8d-c9279da0c78c


```bash
# Paste logs here
```
</details>

---

## ✅ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] My changes generate no new warnings.

---

### _**Generated by GitGenie Contributor Suite**_
