### PR TITLE
fix:Adjust scrollToSection for fixed navbar height

### DIFF
--- a/components/hero-nav.tsx
+++ b/components/hero-nav.tsx
@@ -12,24 +12,37 @@ export default function HeroNav() {
   ];
 
   const scrollToSection = (id: string) => {
-    const el = document.getElementById(id);
-    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+    const element = document.getElementById(id);
+
+    if (element) {
+      const navbarHeight = 80; // height of fixed navbar
+
+      const elementPosition =
+        element.getBoundingClientRect().top + window.scrollY;
+
+      const offsetPosition = elementPosition - navbarHeight;
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: "smooth",
+      });
+    }
   };
 
   return (
-  <nav className="hidden md:flex items-center gap-6 bg-zinc-900/60 backdrop-blur-md border border-zinc-800 rounded-full px-6 py-3 shadow-lg fixed top-4 left-1/2 -translate-x-1/2 z-[110] whitespace-nowrap">
-  {navItems.map((item) => (
-    <button
-      key={item.id}
-      onClick={() => scrollToSection(item.id)}
-      className="text-zinc-300 text-sm font-medium transition-colors duration-200 rounded-full px-3 py-1 
-                 hover:text-amber-400 hover:bg-zinc-700/50 
-                 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 
-                 active:bg-zinc-700/50"
-    >
-      {item.label}
-    </button>
-  ))}
-</nav>
+    <nav className="hidden md:flex items-center gap-6 bg-zinc-900/60 backdrop-blur-md border border-zinc-800 rounded-full px-6 py-3 shadow-lg fixed top-4 left-1/2 -translate-x-1/2 z-[110] whitespace-nowrap">
+      {navItems.map((item) => (
+        <button
+          key={item.id}
+          onClick={() => scrollToSection(item.id)}
+          className="text-zinc-300 text-sm font-medium transition-colors duration-200 rounded-full px-3 py-1 
+          hover:text-amber-400 hover:bg-zinc-700/50
+          focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2
+          active:bg-zinc-700/50"
+        >
+          {item.label}
+        </button>
+      ))}
+    </nav>
   );
 }


### PR DESCRIPTION
## 📝 Description

This update fixes the scrolling behavior of the navigation bar when clicking on a section.

Previously, `scrollintoView()` was used directly, which caused the target section to appear hidden behind the fixed navbar. Because the navbar is fixed at the top of the page, the section heading was not visible after navigation.

This change updates the `scrollToSection` function to calculate the correct scroll position by subtracting the navbar height from the section position.

As a result, clicking a navbar item now scrolls smoothly to the correct section without it being hidden behind the fixed navbar.

Fixes #126

## 🚀 Type of Change

* [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
* [ ] ✨ **New feature** (non-breaking change which adds functionality)
* [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📖 **Documentation update** (adding/improving docs or Mermaid diagrams)
* [ ] 🎨 **Style/Refactor** (non-functional changes, formatting, or renaming)

---

## 🧪 How Has This Been Tested?

The updated scroll behavior was manually tested by navigating through all navbar items.

### Test Steps

1. Start the development server.
2. Open the landing page.
3. Click each navbar item (Features, How it Works, Demo, Usage, Branches, FAQ, Community).
4. Verify that the page scrolls smoothly to the correct section.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior when navigating to page sections to account for the fixed navigation bar, ensuring content is not hidden behind the navigation element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->