### PR TITLE
fix: prevent command injection by replacing execaCommand with execa

### DIFF
--- a/cli/helpers/reflogParser.js
+++ b/cli/helpers/reflogParser.js
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa';
+import { execa } from 'execa';
 
 /**
  * Runs git reflog and parses commit hash and action
@@ -8,7 +8,7 @@ import { execaCommand } from 'execa';
 export async function parseReflog(count = 20) {
   try {
     // Run git reflog with specified count - READ ONLY operation
-    const { stdout } = await execaCommand(`git reflog -n ${count} --format=%H|%gd|%gs|%cr`);
+    const { stdout } = await execa('git', ['reflog', '-n', String(count), '--format=%H|%gd|%gs|%cr']);
     
     if (!stdout.trim()) {
       return [];

--- a/cli/helpers/safeBranchOps.js
+++ b/cli/helpers/safeBranchOps.js
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa';
+import { execa } from 'execa';
 import chalk from 'chalk';
 
 /**
@@ -24,10 +24,10 @@ export async function createRecoveryBranch(commitHash, branchName = null) {
 
   try {
     // Verify the commit exists (READ ONLY check)
-    await execaCommand(`git cat-file -e ${commitHash}`);
+    await execa('git', ['cat-file', '-e', commitHash]);
     
     // Create branch from commit hash - SAFE: no checkout, no reset, no force
-    await execaCommand(`git branch ${finalBranchName} ${commitHash}`);
+    await execa('git', ['branch', finalBranchName, commitHash]);
     
     console.log(chalk.green(`✅ Created recovery branch: ${finalBranchName}`));
     console.log(chalk.gray(`   From commit: ${commitHash}`));
@@ -57,12 +57,12 @@ export async function cherryPickToBranch(targetBranch, commitHashes) {
 
   try {
     // Switch to target branch (SAFE: no force)
-    await execaCommand(`git checkout ${targetBranch}`);
+    await execa('git', ['checkout', targetBranch]);
     
     // Cherry-pick each commit
     for (const hash of commitHashes) {
       try {
-        await execaCommand(`git cherry-pick ${hash}`);
+        await execa('git', ['cherry-pick', hash]);
         console.log(chalk.green(`✅ Applied commit: ${hash.substring(0, 8)}`));
       } catch (error) {
         if (error.message.includes('conflict')) {
@@ -86,8 +86,8 @@ export async function cherryPickToBranch(targetBranch, commitHashes) {
 export async function getCommitInfo(commitHash) {
   try {
     // Get commit details (READ ONLY)
-    const { stdout: commitInfo } = await execaCommand(
-      `git show --format=%H|%an|%ae|%ad|%s --name-only ${commitHash}`
+    const { stdout: commitInfo } = await execa(
+      'git', ['show', '--format=%H|%an|%ae|%ad|%s', '--name-only', commitHash]
     );
     
     const lines = commitInfo.trim().split('\n');
@@ -126,7 +126,7 @@ export async function validateBranchName(branchName) {
 
   try {
     // Check if branch already exists
-    await execaCommand(`git show-ref --verify refs/heads/${branchName}`);
+    await execa('git', ['show-ref', '--verify', `refs/heads/${branchName}`]);
     return false; // Branch exists
   } catch {
     return true; // Branch doesn't exist, name is available

--- a/cli/helpers/undoLogic.js
+++ b/cli/helpers/undoLogic.js
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa';
+import { execa } from 'execa';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { confirmRecoveryAction } from './confirmationPrompt.js';
@@ -17,7 +17,7 @@ import {
  */
 export async function getRecentCommits(count) {
     try {
-        const { stdout } = await execaCommand(`git log --oneline -n ${count}`);
+        const { stdout } = await execa('git', ['log', '--oneline', '-n', String(count)]);
 
         if (!stdout || stdout.trim() === '') {
             return [];
@@ -44,7 +44,7 @@ export async function getRecentCommits(count) {
  */
 export async function checkWorkingDirectoryStatus() {
     try {
-        const { stdout } = await execaCommand('git status --porcelain');
+        const { stdout } = await execa('git', ['status', '--porcelain']);
         return stdout.trim().length > 0;
     } catch (error) {
         throw new UndoError(
@@ -104,7 +104,7 @@ export async function handleUndoSoft(n) {
             return;
         }
 
-        await execaCommand(`git reset --soft HEAD~${n}`);
+        await execa('git', ['reset', '--soft', `HEAD~${n}`]);
 
         console.log(chalk.green(`\n✅ Successfully undid ${n} commit${n === 1 ? '' : 's'}`));
         console.log(chalk.cyan('\n📋 Next steps:'));
@@ -151,7 +151,7 @@ export async function handleUndoMixed(n) {
             return;
         }
 
-        await execaCommand(`git reset --mixed HEAD~${n}`);
+        await execa('git', ['reset', '--mixed', `HEAD~${n}`]);
 
         console.log(chalk.green(`\n✅ Successfully undid ${n} commit${n === 1 ? '' : 's'}`));
         console.log(chalk.cyan('\n📋 Next steps:'));
@@ -206,7 +206,7 @@ export async function handleUndoHard(n) {
             return;
         }
 
-        await execaCommand(`git reset --hard HEAD~${n}`);
+        await execa('git', ['reset', '--hard', `HEAD~${n}`]);
 
         console.log(chalk.green(`\n✅ Hard reset completed`));
         console.log(chalk.yellow(`⚠️  ${n} commit${n === 1 ? '' : 's'} and all changes permanently deleted`));


### PR DESCRIPTION
## 🔒 Security Fix: Command Injection Prevention

**CWE-78: Improper Neutralization of Special Elements used in an OS Command**
**Fixes #148**

### Summary
Replaces all uses of \execaCommand()\ (shell string interpolation) with \execa()\ (arguments array) across CLI helper files to prevent OS command injection via user-controlled inputs.

### Root Cause
\execaCommand()\ passes the entire command string through a shell interpreter. When user-controlled values (commit hashes, branch names, reflog counts) are interpolated directly into these strings, an attacker can inject arbitrary shell commands using characters like \;\, \|\, \\\, or \\\.

### Changes

| File | Count | Pattern Changed |
|------|-------|-----------------|
| \cli/helpers/safeBranchOps.js\ | 6 | \execaCommand(\git ... \\)\ → \execa('git', [...args, input])\ |
| \cli/helpers/reflogParser.js\ | 1 | Same pattern |
| \cli/helpers/undoLogic.js\ | 5 | Same pattern |

### Example Fix
\\\javascript
// Before (VULNERABLE)
await execaCommand(\git cat-file -e \\);

// After (SAFE)  
await execa('git', ['cat-file', '-e', commitHash]);
\\\

The \execa\ package's \execa()\ function with an arguments array does **not** invoke a shell, making injection impossible regardless of input content.

### Testing
All existing CLI tests pass:
\\\
Test Results: 10 passed, 0 failed (errorHandler)
Test Results: 9 passed, 0 failed (providerFactory)
\\\

## GSSoC 2026
This PR is submitted for **GirlScript Summer of Code 2026**. Please add the \gssoc26\ label.

### Checklist
- [x] No shell metacharacters can reach git commands
- [x] All \execaCommand()\ calls with user input migrated to \execa()\
- [x] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal Git command execution in CLI helpers for improved consistency and reliability. No changes to user-facing functionality or CLI commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gunjanghate/GitGenie/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->