### PR TITLE
fix(security): prevent credential exposure in CLI output and logs

### DIFF
--- a/cli/helpers/errorHandler.js
+++ b/cli/helpers/errorHandler.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { sanitizeCredentials } from '../utils/credentialSanitizer.js';
 
 /**
  * Local providers that run on-device — no API keys, different error surface.
@@ -294,16 +295,19 @@ function logErrorToDebugFile(error, providerName, context) {
 
         const timestamp = new Date().toISOString();
         const providerDisplayName = providerName || 'AI Provider';
+        // Sanitize message and stack so credentials in URLs are never written to disk
+        const safeMessage = sanitizeCredentials(error?.message || 'No message');
+        const safeStack = sanitizeCredentials(error?.stack || 'No stack trace available');
         const logEntry = `
 ================================================================================
 [${timestamp}] ${providerDisplayName} API Error - ${context}
 ================================================================================
-Error Message: ${error?.message || 'No message'}
+Error Message: ${safeMessage}
 Error Name: ${error?.name || 'Unknown'}
 Error Code: ${error?.code || 'N/A'}
 Status: ${error?.status || error?.statusCode || 'N/A'}
 Stack Trace:
-${error?.stack || 'No stack trace available'}
+${safeStack}
 ================================================================================
 
 `;

--- a/cli/index.js
+++ b/cli/index.js
@@ -9,6 +9,7 @@ import inquirer from 'inquirer';
 import ora from 'ora';
 import path from 'path';
 import simpleGit from 'simple-git';
+import { sanitizeCredentials, sanitizeRemoteUrl } from './utils/credentialSanitizer.js';
 const {
   registerConfigCommand,
   getActiveProviderInstance,
@@ -167,6 +168,8 @@ program.command('cl')
   .argument('[dir]')
   .description('Clone repository')
   .action(async (url, dir) => {
+    // Sanitize the URL for display — never echo embedded credentials to the terminal
+    const safeUrl = sanitizeRemoteUrl(url);
     const spinner = ora('📥 Cloning repository...').start();
     try {
       await git.clone(url, dir);
@@ -174,7 +177,8 @@ program.command('cl')
       // Determine the target directory name for helpful next steps
       const repoNameFromUrl = (() => {
         try {
-          const parts = url.split('/').filter(Boolean);
+          // Use the sanitized URL so credentials are never part of the derived name
+          const parts = safeUrl.split('/').filter(Boolean);
           const last = parts[parts.length - 1] || '';
           return (last || 'repo').replace(/\.git$/i, '');
         } catch {
@@ -200,8 +204,9 @@ program.command('cl')
       }
     } catch (err) {
       spinner.fail('Failed to clone repository.');
-      console.log(chalk.red(err.message));
-      console.log(chalk.cyan('Tip: Ensure the URL is correct and you have access (SSH/HTTPS).'));
+      // Sanitize the error message — git often echoes the full URL (with credentials) in error output
+      console.log(chalk.red(sanitizeCredentials(err.message)));
+      console.log(chalk.cyan('Tip: Ensure the URL is correct and you have access. Prefer SSH keys or a Git credential helper over inline tokens.'));
     }
   });
 

--- a/cli/utils/credentialSanitizer.js
+++ b/cli/utils/credentialSanitizer.js
@@ -1,0 +1,74 @@
+/**
+ * credentialSanitizer.js
+ *
+ * Utility functions to prevent accidental exposure of credentials
+ * (tokens, passwords, API keys) in console output, error messages, and logs.
+ *
+ * Addresses: https://github.com/gunjanghate/GitGenie/issues/173
+ *
+ * Credentials can appear in:
+ *  - Git remote URLs: https://<token>@github.com/...
+ *                     https://<user>:<password>@github.com/...
+ *  - Error messages from simple-git / child_process that echo the URL
+ *  - Debug log entries
+ */
+
+/**
+ * Regex that matches the user-info portion of a URL
+ * (everything between "://" and the "@" sign before the hostname).
+ *
+ * Covers:
+ *   https://token@host              → https://<redacted>@host
+ *   https://user:password@host      → https://<redacted>@host
+ *   http://user:pass@host:port/path → http://<redacted>@host:port/path
+ */
+const CREDENTIAL_URL_REGEX = /([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)([^@\s/]+@)/g;
+
+/**
+ * Replaces the userinfo segment of any URL in the given string with
+ * the placeholder "[credentials-redacted]".
+ *
+ * @param {string} input - Any string that may contain URLs with embedded credentials.
+ * @returns {string} The sanitized string with credentials replaced.
+ */
+export function sanitizeCredentials(input) {
+  if (typeof input !== 'string') return input;
+  return input.replace(CREDENTIAL_URL_REGEX, '$1[credentials-redacted]@');
+}
+
+/**
+ * Sanitizes an Error object's message in-place (non-destructive copy).
+ * Returns a plain object with the sanitized message so that the original
+ * error is never mutated.
+ *
+ * @param {Error|unknown} error - The error to sanitize.
+ * @returns {{ message: string, stack?: string }} A sanitized error-like object.
+ */
+export function sanitizeError(error) {
+  if (!error) return { message: 'Unknown error' };
+
+  const message = sanitizeCredentials(
+    typeof error.message === 'string' ? error.message : String(error)
+  );
+
+  const stack = error.stack
+    ? sanitizeCredentials(error.stack)
+    : undefined;
+
+  return { ...error, message, stack };
+}
+
+/**
+ * Extracts a display-safe version of a remote URL.
+ * Strips userinfo but preserves the rest of the URL for diagnostic purposes.
+ *
+ * @param {string} url - The raw remote URL (may include credentials).
+ * @returns {string} The URL with credentials redacted.
+ *
+ * @example
+ * sanitizeRemoteUrl('https://ghp_abc123@github.com/user/repo.git')
+ * // → 'https://[credentials-redacted]@github.com/user/repo.git'
+ */
+export function sanitizeRemoteUrl(url) {
+  return sanitizeCredentials(url);
+}


### PR DESCRIPTION
## Problem

When users run commands like `gg cl https://token:password@github.com/repo.git`, the embedded credentials are exposed in two ways:

1. **Terminal output** - git's error messages echo the full URL (with credentials) back to the console.
2. **Debug log file** - When `GITGENIE_DEBUG=true`, error messages and stack traces containing credential-bearing URLs are written to `~/.gitgenie/error.log` in plain text.

Fixes #173

## Root Cause

- `gg cl` catch block: `console.log(chalk.red(err.message))` where git's error output includes the raw URL.
- `logErrorToDebugFile()` in `errorHandler.js`: writes `error.message` and `error.stack` verbatim to disk.

## Fix

### New file: `cli/utils/credentialSanitizer.js`

A focused utility with three exports:
- `sanitizeCredentials(str)` - replaces the userinfo segment (`user:pass@` or `token@`) in any URL with `[credentials-redacted]@`  
- `sanitizeRemoteUrl(url)` - convenience wrapper for git remote URLs  
- `sanitizeError(error)` - returns a sanitized copy of an error object  

### `cli/index.js` (`gg cl` command)
- Compute `safeUrl = sanitizeRemoteUrl(url)` before using the URL for display or name derivation
- Wrap `err.message` with `sanitizeCredentials()` in the catch block
- Update the tip message to recommend SSH keys / credential helpers over inline tokens

### `cli/helpers/errorHandler.js` (`logErrorToDebugFile`)
- Sanitize `error.message` and `error.stack` before appending to the log file

## Testing

Verification steps:
1. Run `gg cl https://badtoken@github.com/nonexistent/repo` - terminal shows `[credentials-redacted]` instead of the token
2. With `GITGENIE_DEBUG=true`, check `~/.gitgenie/error.log` - credentials are redacted
3. Normal clone with a clean HTTPS/SSH URL still works as before