### PR TITLE
fix: remove self-referencing circular dependency from cli/package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "@gunjanghate/git-genie": "^1.0.10",
     "@mistralai/mistralai": "^1.6.0",
     "axios": "^1.11.0",
     "chalk": "^5.5.0",


### PR DESCRIPTION
## Description

Removes the self-referencing dependency where `@gunjanghate/git-genie` listed itself as a dependency in `cli/package.json` (line 46).

## Problem

The `cli/package.json` contained:

```json
"@gunjanghate/git-genie": "^1.0.10",
```

This circular dependency causes:
- `npm install` failures/hangs in some environments
- Dependency resolution warnings
- Confusion for contributors debugging install issues

## Fix

Removed the self-referencing entry from the `dependencies` object. No package should depend on itself.

## Related

Fixes #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up project dependencies to optimize build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->