### PR TITLE
fix: prevent API key exposure via CLI arguments

### DIFF
--- a/cli/commands/config.js
+++ b/cli/commands/config.js
@@ -474,6 +474,7 @@ export function registerConfigCommand(program) {
         // Local provider options (ollama / lmstudio)
         .option('--url <url>', 'Base URL for local AI server (e.g. http://localhost:11434)')
         .option('--model <model>', 'Model name for local AI provider (e.g. llama3.2)')
+        .option('--stdin', 'Read API key from stdin (secure, for scripting)')
         .action(async (apikey, options) => {
             try {
                 const { ProviderFactory } = await import('../providers/index.js');
@@ -513,7 +514,9 @@ export function registerConfigCommand(program) {
                     console.log(''); // Empty line
                     if (!hasConfigured) {
                         console.log(chalk.yellow('  No providers configured yet.'));
-                        console.log(chalk.cyan('  Cloud:  gg config <your-key> --provider <name>'));
+                        console.log(chalk.cyan('  Cloud:  gg config --provider <name>     (secure interactive mode)'));
+                        console.log(chalk.cyan('  Cloud:  echo "<key>" | gg config --stdin --provider <name>     (scripting)'));
+                        console.log(chalk.cyan('  Cloud:  export GEMINI_API_KEY="<key>"     (environment variable)'));
                         console.log(chalk.cyan('  Local:  gg config --provider ollama --url http://localhost:11434 --model llama3.2'));
                     }
                     process.exit(0);
@@ -554,11 +557,36 @@ export function registerConfigCommand(program) {
                 }
 
                 // Mode 2b: Save cloud provider API key
-                if (!apikey) {
-                    console.error(chalk.red('Error: API key is required for cloud providers when not using --status'));
-                    console.log(chalk.cyan('Usage: gg config <apikey> --provider <name>'));
-                    console.log(chalk.cyan('Check Status: gg config --status'));
-                    process.exit(1);
+                if (options.stdin) {
+                    const readline = await import('readline');
+                    const rl = readline.createInterface({ input: process.stdin });
+                    const keyFromStdin = await new Promise(resolve => {
+                        let data = '';
+                        rl.on('line', line => { data += line; });
+                        rl.on('close', () => resolve(data.trim()));
+                    });
+                    if (!keyFromStdin) {
+                        console.error(chalk.red('Error: No API key provided via stdin.'));
+                        process.exit(1);
+                    }
+                    apikey = keyFromStdin;
+                } else if (!apikey) {
+                    const { default: inquirer } = await import('inquirer');
+                    const { secretKey } = await inquirer.prompt([{
+                        type: 'password',
+                        name: 'secretKey',
+                        message: `Enter your ${providerName} API key (input will be hidden):`,
+                        validate: input => input.trim().length > 0 ? true : 'API key cannot be empty'
+                    }]);
+                    apikey = secretKey;
+                } else {
+                    console.warn(chalk.yellow('⚠  Security: Passing API keys as CLI arguments is insecure.'));
+                    console.warn(chalk.yellow('   The key is visible in shell history, process listings, and terminal logs.'));
+                    console.warn(chalk.cyan('   Safer alternatives:'));
+                    console.warn(chalk.cyan('     • Set the environment variable: export GEMINI_API_KEY=your_key'));
+                    console.warn(chalk.cyan('     • Use interactive mode (just run: gg config --provider <name>)'));
+                    console.warn(chalk.cyan('     • Pipe via stdin: echo "your_key" | gg config --stdin --provider <name>'));
+                    console.warn('');
                 }
 
                 await saveProviderApiKey(providerName, apikey);

--- a/cli/index.js
+++ b/cli/index.js
@@ -138,7 +138,7 @@ ${banner}
       '\nTry your first AI-powered commit:\n' +
       chalk.magenta('   gg "your changes" --genie\n') +
       chalk.yellow("⚡ Unlock Genie powers:") +
-      '\n   gg config <your_api_key>\n' +
+      '\n   gg config --provider gemini\n' +
       chalk.cyan("Or just get started with a manual commit:") +
       '\n' + chalk.magenta('   gg "your commit message"\n') +
       chalk.blue("📖 Docs & guide: https://gitgenie.vercel.app/\n");


### PR DESCRIPTION
## Description

Prevents API key exposure by changing the `gg config` command to use secure input methods instead of accepting keys as CLI arguments.

## Problem

The `gg config <apikey>` command accepted API keys directly as command-line positional arguments, exposing them in:
- Shell history files (.bash_history, .zsh_history, PowerShell history)
- Process listings (ps aux, Task Manager)
- Terminal scrollback buffers
- CI logs when used in scripts

## Changes

1. **Default to interactive password prompt**: When no API key is provided as argument, uses inquirer password input (hidden input, not echoed to terminal)
2. **Added `--stdin` flag**: For secure scripting: `echo "key" | gg config --stdin --provider gemini`
3. **Security warning**: When API key is passed as CLI argument, shows a warning about the security risk and recommends secure alternatives
4. **Updated help text**: Help output now shows secure methods first

## Example Usage

```bash
# Secure: interactive prompt (hidden input) - RECOMMENDED
gg config --provider gemini

# Secure: pipe via stdin (for scripting)
echo "your-key" | gg config --stdin --provider gemini

# Secure: environment variable
export GEMINI_API_KEY="your-key"
```

## Related

Fixes #199
