### PR TITLE
fix: add validation for empty and blank API keys

### DIFF
--- a/cli/commands/config.js
+++ b/cli/commands/config.js
@@ -220,17 +220,28 @@ export async function getProviderApiKey(providerName) {
  */
 export async function saveProviderApiKey(providerName, apikey) {
     // Validate input
-    if (!apikey || typeof apikey !== 'string' || apikey.trim().length === 0) {
+    if (!apikey || typeof apikey !== 'string') {
         throw new Error('API key must be a non-empty string');
     }
 
     const trimmedApiKey = apikey.trim();
+
+    if (trimmedApiKey.length === 0) {
+        throw new Error('API key cannot be empty or contain only whitespace');
+    }
+
+    // Validate against provider-specific rules
+    const validated = validateApiKey(providerName, trimmedApiKey);
+    if (!validated) {
+        throw new Error(`Invalid API key format for provider "${providerName}". Please check your API key and try again.`);
+    }
+
     const keytarAccount = `${providerName}_api_key`;
 
     if (keytar) {
         try {
             // Try to save to keytar first (secure storage)
-            await keytar.setPassword(SERVICE_NAME, keytarAccount, trimmedApiKey);
+            await keytar.setPassword(SERVICE_NAME, keytarAccount, validated);
         } catch (error) {
             // Keytar failed, fallback to config.json (encrypted)
         }
@@ -246,7 +257,7 @@ export async function saveProviderApiKey(providerName, apikey) {
         if (!config.providers) config.providers = {};
 
         // Encrypt and save API key
-        const encryptedKey = await encrypt(trimmedApiKey);
+        const encryptedKey = await encrypt(validated);
         config.providers[providerName] = {
             apiKey: encryptedKey,
             configuredAt: new Date().toISOString()
@@ -561,12 +572,24 @@ export function registerConfigCommand(program) {
                     process.exit(1);
                 }
 
+                if (typeof apikey === 'string' && apikey.trim().length === 0) {
+                    console.error(chalk.red('Error: API key cannot be empty or contain only whitespace'));
+                    console.log(chalk.yellow('Please provide a valid API key for your provider'));
+                    console.log(chalk.cyan('Usage: gg config <your-api-key> --provider <name>'));
+                    process.exit(1);
+                }
+
                 await saveProviderApiKey(providerName, apikey);
                 console.log(chalk.green(`${providerName.charAt(0).toUpperCase() + providerName.slice(1)} API key saved successfully!`));
                 console.log(chalk.cyan(`${providerName} is now your active AI provider`));
             } catch (err) {
                 console.error(chalk.red('Failed to save configuration.'));
                 console.error(chalk.yellow(err.message));
+                console.log(chalk.gray(''));
+                console.log(chalk.cyan('Troubleshooting tips:'));
+                console.log(chalk.gray('  1. Ensure your API key is not empty or only whitespace'));
+                console.log(chalk.gray('  2. Check that you are using the correct provider name'));
+                console.log(chalk.gray('  3. Verify your API key format matches the expected pattern'));
             }
             process.exit(0);
         });

--- a/cli/tests/apiKeyValidation.test.js
+++ b/cli/tests/apiKeyValidation.test.js
@@ -1,0 +1,95 @@
+import { validateApiKey } from '../utils/resolveApiKey.js';
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+let passed = 0;
+let failed = 0;
+
+function run(name, fn) {
+    try {
+        fn();
+        console.log(`✓ ${name}`);
+        passed++;
+    } catch (err) {
+        console.error(`✗ ${name}: ${err.message}`);
+        failed++;
+    }
+}
+
+// Test empty string rejection
+run('rejects empty API key string', () => {
+    assert(validateApiKey('gemini', '') === null);
+});
+
+// Test whitespace-only rejection
+run('rejects whitespace-only API key', () => {
+    assert(validateApiKey('gemini', '   ') === null);
+});
+
+run('rejects API key with only tabs', () => {
+    assert(validateApiKey('gemini', '\t\t\t') === null);
+});
+
+run('rejects API key with only newlines', () => {
+    assert(validateApiKey('gemini', '\n\n\n') === null);
+});
+
+// Test null and undefined rejection
+run('rejects null API key', () => {
+    assert(validateApiKey('gemini', null) === null);
+});
+
+run('rejects undefined API key', () => {
+    assert(validateApiKey('gemini', undefined) === null);
+});
+
+run('rejects non-string API key', () => {
+    assert(validateApiKey('gemini', 123) === null);
+});
+
+// Test valid key acceptance
+run('accepts valid Gemini API key', () => {
+    const result = validateApiKey('gemini', 'AIzaSyDummyKeyForValidation123456');
+    assert(result !== null);
+});
+
+run('trims whitespace from valid key', () => {
+    const result = validateApiKey('gemini', '  AIzaSyDummyKeyForValidation123456  ');
+    assert(result === 'AIzaSyDummyKeyForValidation123456');
+});
+
+// Test key length validation
+run('rejects API key that exceeds maximum length', () => {
+    const longKey = 'AIzaSy' + 'a'.repeat(195);
+    assert(validateApiKey('gemini', longKey) === null);
+});
+
+// Test provider-specific validation
+run('accepts valid Groq API key format', () => {
+    const result = validateApiKey('groq', 'gsk_DummyKeyWithValidFormat1234567890');
+    assert(result !== null);
+});
+
+run('rejects invalid Groq API key prefix', () => {
+    assert(validateApiKey('groq', 'AIzaSyDummyKeyForValidation123456') === null);
+});
+
+run('accepts valid OpenAI API key format', () => {
+    const result = validateApiKey('openai', 'sk-DummyKeyWithValidFormat1234567890');
+    assert(result !== null);
+});
+
+// Test invalid character rejection
+run('rejects API key with special characters not in allowlist', () => {
+    assert(validateApiKey('gemini', 'AIzaSy@invalid#key$here') === null);
+});
+
+if (failed > 0) {
+    process.exit(1);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Fixes #153: gg config allows saving empty or blank string spaces as valid API Keys

## Summary
This PR adds comprehensive validation to prevent saving empty or whitespace-only API keys in the configuration system. It validates against provider-specific format rules to ensure users can only save valid API keys.

## Changes Made
- Enhanced saveProviderApiKey function to validate against provider-specific formats
- Added early validation check in config command handler with clear error messages
- Improved error output with helpful troubleshooting tips
- Added comprehensive test suite (apiKeyValidation.test.js) covering:
  - Empty string rejection
  - Whitespace-only string rejection
  - Null/undefined rejection
  - Non-string type rejection
  - Valid key acceptance with whitespace trimming
  - Provider-specific validation
  - Maximum length enforcement

## Test Plan
1. Test empty API key rejection: `gg config "" --provider gemini`
2. Test whitespace-only rejection: `gg config "   " --provider gemini`
3. Test valid key acceptance: `gg config "AIzaSyValidKey..." --provider gemini`
4. Run test suite: `node cli/tests/apiKeyValidation.test.js`
5. Verify error messages guide users on invalid input

All 14 new validation tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API key validation now strictly rejects empty, whitespace-only, and improperly formatted values with clear, actionable error messages
  * Enhanced error messages include detailed troubleshooting guidance and verification steps when API key configuration or validation fails
  * Provider-specific validation ensures API keys meet the exact format requirements for each supported cloud service provider
  * Automatic whitespace trimming during input eliminates accidental spacing and unwanted formatting errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->