### PR TITLE
fix: prevent API key credential exposure via CLI args in error messages and add --stdin flag (Closes #211)

### DIFF
--- a/cli/commands/config.js
+++ b/cli/commands/config.js
@@ -471,6 +471,7 @@ export function registerConfigCommand(program) {
         .description('Save your AI provider API key or check configuration status')
         .option('--provider <name>', 'Provider name (gemini, mistral, groq, ollama, lmstudio)', 'gemini')
         .option('--status', 'Check configuration status of all providers')
+        .option('--stdin', 'Read API key from stdin (secure, avoids shell history exposure)')
         // Local provider options (ollama / lmstudio)
         .option('--url <url>', 'Base URL for local AI server (e.g. http://localhost:11434)')
         .option('--model <model>', 'Model name for local AI provider (e.g. llama3.2)')
@@ -513,7 +514,7 @@ export function registerConfigCommand(program) {
                     console.log(''); // Empty line
                     if (!hasConfigured) {
                         console.log(chalk.yellow('  No providers configured yet.'));
-                        console.log(chalk.cyan('  Cloud:  gg config <your-key> --provider <name>'));
+                        console.log(chalk.cyan('  Cloud:  echo "your_key" | gg config --stdin --provider <name>'));
                         console.log(chalk.cyan('  Local:  gg config --provider ollama --url http://localhost:11434 --model llama3.2'));
                     }
                     process.exit(0);
@@ -554,9 +555,19 @@ export function registerConfigCommand(program) {
                 }
 
                 // Mode 2b: Save cloud provider API key
+                if (options.stdin) {
+                    const stdinChunks = [];
+                    for await (const chunk of process.stdin) {
+                        stdinChunks.push(chunk);
+                    }
+                    apikey = Buffer.concat(stdinChunks).toString('utf-8').trim();
+                }
+
                 if (!apikey) {
                     console.error(chalk.red('Error: API key is required for cloud providers when not using --status'));
-                    console.log(chalk.cyan('Usage: gg config <apikey> --provider <name>'));
+                    console.log(chalk.cyan('Secure usage: gg config --stdin --provider <name>'));
+                    console.log(chalk.cyan('        or:  echo "your_key" | gg config --stdin --provider <name>'));
+                    console.log(chalk.cyan('        or:  export GEMINI_API_KEY="your_key"'));
                     console.log(chalk.cyan('Check Status: gg config --status'));
                     process.exit(1);
                 }

--- a/cli/helpers/errorHandler.js
+++ b/cli/helpers/errorHandler.js
@@ -210,7 +210,8 @@ export function parseProviderError(error, providerName = 'gemini') {
         errorType = ErrorType.INVALID_API_KEY;
         userMessage = 'AI generation failed: Invalid or missing API key.';
         helpfulAction = `Please reconfigure your ${providerDisplayName} API key:
-   ${chalk.gray(`gg config <your_api_key> --provider ${providerName}`)}
+   Secure method: export ${providerName.toUpperCase()}_API_KEY="your_key"
+   Or pipe: echo "your_key" | gg config --stdin --provider ${providerName}
    Get your key at: ${chalk.cyan(patterns.docsUrl)}`;
     }
     // Check for network errors
@@ -238,14 +239,16 @@ export function parseProviderError(error, providerName = 'gemini') {
         errorType = ErrorType.GENERIC_API_ERROR;
         userMessage = 'AI generation failed due to an API error.';
         helpfulAction = `Check your API key and network connection:
-   ${chalk.gray(`gg config <your_api_key> --provider ${providerName}`)}`;
+   Secure method: export ${providerName.toUpperCase()}_API_KEY="your_key"
+   Or pipe: echo "your_key" | gg config --stdin --provider ${providerName}`;
     }
     // Unknown error
     else {
         errorType = ErrorType.UNKNOWN_ERROR;
         userMessage = 'AI generation failed unexpectedly.';
         helpfulAction = `Please check your configuration and try again:
-   ${chalk.gray(`gg config <your_api_key> --provider ${providerName}`)}`;
+   Secure method: export ${providerName.toUpperCase()}_API_KEY="your_key"
+   Or pipe: echo "your_key" | gg config --stdin --provider ${providerName}`;
     }
 
     return {


### PR DESCRIPTION
## Description

Fixes a credential exposure vulnerability (Closes #211) where error messages and the config command encouraged users to pass API keys as CLI arguments, exposing them in shell history, process listings, and terminal scrollback.

## Changes

### `cli/helpers/errorHandler.js`
Updated all three error message blocks (invalid API key, generic API error, unknown error) to recommend secure alternatives instead of CLI args:
- Environment variable: `export PROVIDER_API_KEY="your_key"`
- Stdin piping: `echo "your_key" | gg config --stdin --provider <name>`

### `cli/commands/config.js`
- Added `--stdin` option to read API key from stdin securely
- Updated the "no providers configured" message to show the stdin method
- Updated the error message when no API key is provided to show secure alternatives

## Before
```
gg config <your_api_key> --provider gemini
```

## After
```
export GEMINI_API_KEY="your_key"
echo "your_key" | gg config --stdin --provider gemini
```

## Verification
- `echo "test-key" | node cli/index.js config --stdin --provider gemini` reads key from stdin correctly
- `gg config --stdin --provider gemini` waits for stdin input
- Existing `gg config <key> --provider gemini` still works (backward compatible)
