### PR TITLE
fix: include all essential directories in npm package files

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,6 +10,10 @@
   },
   "files": [
     "index.js",
+    "commands/",
+    "helpers/",
+    "providers/",
+    "utils/",
     "scripts/",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## Description

The \iles\ field in \cli/package.json\ was missing several essential directories, causing the CLI to completely fail at runtime when installed from npm.

## Changes

Added the following directories to the \iles\ array in \cli/package.json\:
- \commands/\ — contains \config.js\, \pr.js\, \split.js\
- \helpers/\ — contains all helper modules (gitUtils, errorHandler, statusLogic, etc.)
- \providers/\ — contains all AI provider implementations (gemini, mistral, groq, ollama, lmstudio)
- \utils/\ — contains \esolveApiKey.js\

## Impact

Without these directories, every dynamic import in \cli/index.js\ fails at runtime, making the CLI completely non-functional when installed via npm.

**Before:** Only \index.js\, \scripts/\, \README.md\, \LICENSE\ were included
**After:** All directories needed at runtime are included

## Related Issue

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded package distribution contents to ensure additional source modules are included when installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->