### PR TITLE
docs: fix incorrect repository URL and folder name in contributor cloning instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -676,8 +676,8 @@ Click `Fork` on GitHub to create your own copy of the repository.
 **_2️⃣ Clone Your Fork_**
 
 ```bash
-git clone https://github.com/<your-username>/gitgenie-cli.git
-cd gitgenie-cli
+git clone https://github.com/<your-username>/GitGenie.git
+cd GitGenie
 ```
 
 **_3️⃣ Install Dependencies_**


### PR DESCRIPTION
## 📝 Description

Fixes #None (just a documentation fix)

This PR resolves a friction point for new contributors by correcting the repository URL and folder name in the "How to Clone & Run GitGenie Locally" section. Previously, following the guide as written resulted in a `fatal: repository not found` error. Updating `gitgenie-cli` to `GitGenie` ensures a smooth and error-free local setup experience.

---

## 🚀 Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 **Documentation update** (adding/improving docs or Mermaid diagrams)
- [ ] 🎨 **Style/Refactor** (non-functional changes, formatting, or renaming)

---

## 🧪 How Has This Been Tested?

- **Test Environment:** - **Node Version:** N/A (Documentation fix)
  - **OS:** N/A
  - **Shell:** N/A

- **Command(s) Executed:**
  - `git clone https://github.com/<your-username>/GitGenie.git`
  - `cd GitGenie`

- **Expected Result:**
  - The repository clones successfully and the directory change works without "folder not found" errors.

- **Actual Result:**
  - Commands execute flawlessly without throwing a `fatal` git error.

---

## ⚠️ Breaking Changes
- [x] **No**
- [ ] **Yes** (If yes, please explain the impact and why it is necessary)

---

## 📸 Screenshots / Logs

<details>
<summary>Click to expand logs</summary>

```bash
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "How to Clone & Run GitGenie Locally" instructions with the correct repository URL for cloning the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->